### PR TITLE
remove repeative log entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 NAME := k8s-custom-iptables
 SRCS := run.sh
 
-TAG ?= 1.0
-REGISTRY=gcr.io/google_containers
+TAG ?= 1.2
+REGISTRY=bisontrails
 IMAGE := $(REGISTRY)/$(NAME):$(TAG)
 
 ifeq ($(REGISTRY),)
@@ -28,7 +28,7 @@ endif
 all: push
 
 push: image
-	gcloud docker -- push $(IMAGE)
+	docker -- push $(IMAGE)
 
 image: Dockerfile $(SRCS)
 	docker build -f Dockerfile -t $(IMAGE) .

--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,6 @@ update_nat() {
     if ${IPTABLES} -t nat -C POSTROUTING -d ${subnet} \
         -m comment --comment "${comment}" -j MASQUERADE -w ${WAIT_INTERVAL}\
         2>/dev/null; then
-      log "NAT rule ${comment} is installed"
       return
     fi
   fi


### PR DESCRIPTION
# What
Remove repetitive log entry that could cause disk pressure on the daemonset over time.

# Test
testing in staging-gcp-us-east1
 